### PR TITLE
Fix curses reinitialization

### DIFF
--- a/main.py
+++ b/main.py
@@ -62,6 +62,7 @@ def show_progress_bar(stdscr, message="Generating Map...", duration=3):
     time.sleep(0.5)
 
 def main(stdscr):
+    init_curses(stdscr)
     while True:
         mode = main_menu(stdscr)
         if mode == "quit":

--- a/network/client.py
+++ b/network/client.py
@@ -38,6 +38,11 @@ class Game:
         self.stdscr = stdscr
         self.sock = sock
         curses.curs_set(0)
+        curses.start_color()
+        curses.use_default_colors()
+        curses.init_pair(1, curses.COLOR_YELLOW, -1)
+        curses.mousemask(curses.ALL_MOUSE_EVENTS | curses.REPORT_MOUSE_POSITION)
+        curses.mouseinterval(0)
         self.stdscr.nodelay(True)
         self.stdscr.timeout(50)
         self.game_map = None
@@ -378,6 +383,11 @@ class Game:
                     damage = 0
                 self.stdscr = curses.initscr()
                 curses.curs_set(0)
+                curses.start_color()
+                curses.use_default_colors()
+                curses.init_pair(1, curses.COLOR_YELLOW, -1)
+                curses.mousemask(curses.ALL_MOUSE_EVENTS | curses.REPORT_MOUSE_POSITION)
+                curses.mouseinterval(0)
                 self.stdscr.nodelay(True)
                 self.stdscr.timeout(50)
                 attack_command = {"attack": True,


### PR DESCRIPTION
## Summary
- setup curses at startup of the game
- reinitialize color and mouse settings when reentering the main interface after combat

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6841b5b972688329ac6937e7fced7e36